### PR TITLE
scikit-learn: fix library directories

### DIFF
--- a/recipes-devtools/python/python3-scikit-learn_1.1.1.bb
+++ b/recipes-devtools/python/python3-scikit-learn_1.1.1.bb
@@ -16,7 +16,7 @@ inherit setuptools3 pkgconfig python3-dir
 export PYTHON_CROSSENV = "1"
 export SKLEARN_BUILD_PARALLEL = "${@oe.utils.cpu_count()}"
 export NPY_PKG_CONFIG_PATH = "${WORKDIR}/npy-pkg-config"
-export NUMPY_INCLUDE_PATH = "${STAGING_DIR_TARGET}/usr/lib/python${PYTHON_BASEVERSION}/site-packages/numpy/core/include"
+export NUMPY_INCLUDE_PATH = "${STAGING_DIR_TARGET}${libdir}/python${PYTHON_BASEVERSION}/site-packages/numpy/core/include"
 
 # Tell Numpy to look in target sysroot site-packages directory for libraries
 LDFLAGS:append = " -L${STAGING_LIBDIR}/${PYTHON_DIR}/site-packages/numpy/core/lib"
@@ -27,9 +27,9 @@ do_compile:prepend() {
 	echo "include_dirs = ${STAGING_INCDIR}" >> ${S}/site.cfg
 
 	mkdir -p ${WORKDIR}/npy-pkg-config
-	cp ${STAGING_DIR_TARGET}/usr/lib/python${PYTHON_BASEVERSION}/site-packages/numpy/core/lib/npy-pkg-config/* ${WORKDIR}/npy-pkg-config
-	sed -i 's&prefix=${pkgdir}&prefix=${STAGING_DIR_TARGET}/usr/lib/python${PYTHON_BASEVERSION}/site-packages/numpy/core&g' ${WORKDIR}/npy-pkg-config/npymath.ini
-	sed -i 's&prefix=${pkgdir}&prefix=${STAGING_DIR_TARGET}/usr/lib/python${PYTHON_BASEVERSION}/site-packages/numpy/core&g' ${WORKDIR}/npy-pkg-config/mlib.ini
+	cp ${STAGING_DIR_TARGET}${libdir}/python${PYTHON_BASEVERSION}/site-packages/numpy/core/lib/npy-pkg-config/* ${WORKDIR}/npy-pkg-config
+	sed -i 's&prefix=${pkgdir}&prefix=${STAGING_DIR_TARGET}${libdir}/python${PYTHON_BASEVERSION}/site-packages/numpy/core&g' ${WORKDIR}/npy-pkg-config/npymath.ini
+	sed -i 's&prefix=${pkgdir}&prefix=${STAGING_DIR_TARGET}${libdir}/python${PYTHON_BASEVERSION}/site-packages/numpy/core&g' ${WORKDIR}/npy-pkg-config/mlib.ini
 }
 
 DEPENDS += " \


### PR DESCRIPTION
Using the standard library directory variable instead of a hardcoded path improves compatibility with different types of systems. For example, it fixes compatibility with systems that need multilib support for coexisting 32bit and 64bit libraries.